### PR TITLE
Remove 360, lenis scroll overtaking

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -62,7 +62,7 @@ useHead({
 });
 
 onMounted(() => {
-  const lenis = new Lenis({ autoRaf: true, overscroll: true })
+  const lenis = new Lenis({ autoRaf: true, overscroll: true, prevent: (node) => !!node.querySelector('[role="presentation"]') })
 
   function handleAnchorLinks() {
     document.querySelectorAll('a[href^="#"]').forEach((anchor) => {

--- a/pages/models/[id]/index.vue
+++ b/pages/models/[id]/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useContainer } from '@/composables/useContainer'
-import ModelUIDoubleTab from '~/components/organisms/(models)/(model)/(index)/model-ui/ModelUIDoubleTab.vue';
 import type { ModelLandingPage } from '~/server/api/models/[id]/index.get';
 
 const { bounding } = useContainer()
@@ -77,7 +76,7 @@ onMounted(() => {
       </ElementSlideView>
     </MoleculeSection>
 
-    <OrganismModelThreeSixty :model-name="pageData?.model.name" :colors="pageData?.model.colors || []" />
+    <!-- <OrganismModelThreeSixty :model-name="pageData?.model.name" :colors="pageData?.model.colors || []" /> -->
 
     <MoleculeSection
 id="shit" :section-title="$t('common.model_variants', { model: pageData?.model.name })"


### PR DESCRIPTION
- **feat: prevent lenis from scrolling over for popover elements**
- **chore: remove three sixty from model landing temporarily**
